### PR TITLE
Add Docker image pull instructions to README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Deploy to DockerHub
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ The Coalition for Content Provenance and Authenticity (C2PA) is an open technica
 - Curl (for testing)
 
 ## Installation
+### Option 1: Pull the Docker image directly
+Pull the pre-built Docker image:
+``` bash
+docker pull oleexo/c2pa-check
+```
+
+### Option 2: Clone and build from source
 Clone this repository:
+
 ``` bash
 git clone https://github.com/yourusername/c2pa-check.git
 cd c2pa-check


### PR DESCRIPTION
Included steps to pull the pre-built Docker image as an installation option. This provides an easier alternative to building from source for users.