### PR TITLE
Update c2pa lib and fix docker running issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
           context: .
           file: ./src/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,9 +319,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "c2pa"
-version = "0.49.3"
+version = "0.49.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5badbd5c27050552366f4309023e35643d56069a35f45f0efd597952a5de6627"
+checksum = "c0be8bd9c6a7c5c65da2f052eba8218aae063838fba94c234c6b631e08c3d3e2"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "c2pa-status-tracker"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65523701dd13e10b1903334a882c7d81c2e3ed4989fec80d2b9a08f732c707a7"
+checksum = "ad3c0107b0fc1208441689e15b22589a090b2c449f42b74d648c55a7fbdc3591"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 rocket = "0.5.1"
-c2pa = { version = "0.49.3", features = ["file_io"] }
+c2pa = { version = "0.49.4", features = ["file_io"] }
 tokio = "1.44.2"

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update && apt-get install -y \
     curl
 
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo "fn main() {}" > src/main.rs
-RUN cargo build --release
+#RUN mkdir src && echo "fn main() {}" > src/main.rs
+#RUN cargo build --release
+#RUN rm /build/target/release/c2pa-check && rm src/main.rs
 
 COPY [ "src/", "src" ]
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.86 as builder
+FROM rust:1.86 AS builder
 LABEL authors="oleexo"
 
 WORKDIR /build
@@ -17,7 +17,7 @@ COPY [ "src/", "src" ]
 
 RUN cargo build --release
 
-FROM debian:bookworm-slim as final
+FROM debian:bookworm-slim AS final
 EXPOSE 8080
 WORKDIR /app
 


### PR DESCRIPTION
# Features
- Bump c2pa from `0.49.3` to `0.49.4`
- Fix running issue in docker container
- Add arm64 target on deploy 