### PR TITLE
Update file upload limits and restructure health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The service will be available at `http://localhost:8080`.
 ### API Endpoints
 #### Health Check
 ``` 
-GET /health
-GET /live
+GET /healtz/health
+GET /healtz/live
 ```
 Returns "OK" when the service is running correctly.
 #### Homepage

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The service will be available at `http://localhost:8080`.
 ### API Endpoints
 #### Health Check
 ``` 
-GET /healtz/health
-GET /healtz/live
+GET /healthz/health
+GET /healthz/live
 ```
 Returns "OK" when the service is running correctly.
 #### Homepage

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,12 +61,12 @@ async fn check(form: Form<FileUpload<'_>>) -> (Status, (ContentType, String)) {
     (Status::Ok, (ContentType::JSON, json_response))
 }
 
-#[get("/healtz/health")]
+#[get("/healthz/health")]
 fn health() -> &'static str {
     "OK"
 }
 
-#[get("/healtz/live")]
+#[get("/healthz/live")]
 fn live() -> &'static str {
     "OK"
 }


### PR DESCRIPTION
Introduced 10 MiB size limits for file uploads and form data for better control over request payloads. Changed health-related routes to reside under the "/healthz" path for improved organization. Updated the README to reflect these endpoint changes.