### PR TITLE
Rename health check routes for consistency and clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The service will be available at `http://localhost:8080`.
 ### API Endpoints
 #### Health Check
 ``` 
-GET /healthz/health
+GET /healthz/ready
 GET /healthz/live
 ```
 Returns "OK" when the service is running correctly.

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,12 +61,12 @@ async fn check(form: Form<FileUpload<'_>>) -> (Status, (ContentType, String)) {
     (Status::Ok, (ContentType::JSON, json_response))
 }
 
-#[get("/healthz/health")]
+#[get("/ready")]
 fn health() -> &'static str {
     "OK"
 }
 
-#[get("/healthz/live")]
+#[get("/live")]
 fn live() -> &'static str {
     "OK"
 }
@@ -90,5 +90,5 @@ fn rocket() -> _ {
     };
     
     rocket::custom(config).mount("/", routes![index, check])
-        .mount("/live", routes![health, live])
+        .mount("/healthz", routes![health, live])
 }


### PR DESCRIPTION
Updated `/healthz/health` to `/ready` and `/healthz/live` to `/live` in the code. Adjusted the `mount` path to `/healthz` and updated the README accordingly to reflect these changes. This improves endpoint naming and alignment.