### PR TITLE
Add Prometheus metrics integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,10 +390,12 @@ dependencies = [
 
 [[package]]
 name = "c2pa-check"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "c2pa",
+ "prometheus",
  "rocket",
+ "rocket_prometheus",
  "tokio",
 ]
 
@@ -2211,6 +2213,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags",
+ "hex",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "proptest"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,6 +2267,12 @@ dependencies = [
  "regex-syntax 0.8.5",
  "unarray",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quick-xml"
@@ -2553,6 +2601,16 @@ dependencies = [
  "time",
  "tokio",
  "uncased",
+]
+
+[[package]]
+name = "rocket_prometheus"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f429d654a6854abef0a5361235e847b6552d5d989c2fc8a312ba4aebd8837f"
+dependencies = [
+ "prometheus",
+ "rocket",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,16 @@
 [package]
 name = "c2pa-check"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
+authors = ["oleexo"]
+license-file = "LICENSE"
 
 [dependencies]
 rocket = "0.5.1"
+rocket_prometheus = { version = "0.10.1", features = [] }
+prometheus = { version = "=0.13", features = ["process"] }
 c2pa = { version = "0.49.5", features = ["file_io"] }
 tokio = "1.44.2"
+
+[badges]
+maintenance = { status = "passively-maintained" }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Coalition for Content Provenance and Authenticity (C2PA) is an open technica
 - Docker and Docker Compose
 - Curl (for testing)
 
+
 ## Installation
 ### Option 1: Pull the Docker image directly
 Pull the pre-built Docker image:
@@ -33,19 +34,14 @@ Start the service using Docker Compose:
 docker compose up
 ```
 The service will be available at `http://localhost:8080`.
-### API Endpoints
-#### Health Check
-``` 
-GET /healthz/ready
-GET /healthz/live
-```
-Returns "OK" when the service is running correctly.
-#### Homepage
-``` 
-GET /
-```
-Returns a simple welcome message.
-#### C2PA Verification
+
+## Configuration
+### Environment Variables
+
+- `FILE_SIZE_LIMIT_MB`: Maximum file size limit in megabytes for uploaded files (default: 10)
+
+## API Endpoints
+### C2PA Verification
 ``` 
 POST /check
 ```
@@ -56,19 +52,35 @@ Submit a file via multipart form data to check for C2PA manifests.
 **Response:**
 - JSON object containing the C2PA manifest data or an error message
 
-### Example
+#### Example
 To test with a sample image:
 ``` bash
 curl -X POST http://localhost:8080/check -v \
   -F "file=@/path/to/your/image.jpg" \
   -H "Content-Type: multipart/form-data"
 ```
+### Health Check
+``` 
+GET /healthz/ready
+GET /healthz/live
+```
+Returns "OK" when the service is running correctly.
+### Prometheus
+```
+GET /metrics
+```
+Returns prometheus metrics with `process*` and `rocket_*` for http web metrics
+### Homepage
+``` 
+GET /
+```
+Returns a simple welcome message.
 ## Development
 This project is built with:
 - Rust 1.86.0
-- Rocket 0.5.1 (web framework)
-- c2pa 0.49.2 (Content Credentials SDK)
-- Tokio 1.44.2 (async runtime)
+- Rocket 0.5.x (web framework)
+- c2pa 0.49.x (Content Credentials SDK)
+- Tokio 1.44.x (async runtime)
 
 To build locally:
 ``` bash


### PR DESCRIPTION
Integrated Prometheus metrics collection using `rocket_prometheus` for monitoring HTTP requests and process stats. Added an environment variable `FILE_SIZE_LIMIT_MB` to configure maximum file upload size dynamically, with a default of 10 MB. Updated dependencies and documentation to reflect these changes.